### PR TITLE
Fixed a potential stack overflow

### DIFF
--- a/src/net_utils.c
+++ b/src/net_utils.c
@@ -128,20 +128,18 @@ int get_ip_of_host(const char *host_name, int af, char *IP)
  *
  * in:   if_name - network interface name in a string format of such "eth0"
  *       af      - valid address types are AF_INET and AF_INET6
-         addr    - a pointer to the structure of the address,
- *                 which will be copied to the host address.
- *                 This format is an IP address is necessary
- *                 in functions such as connect()
+         addr    - a pointer to the structure of the sockaddr_in or sockaddr_in,
+ *                 which the host address will be copied to .
  *
  * ret:  0 - success
  *      -1 - failure (see errno)
  */
-int get_addr_of_if(const char *if_name, int af, void *addr)
+int get_addr_of_if(const char *if_name, int af, void *addr, int addr_len)
 {
 
     struct ifaddrs *ifa_head;
     struct ifaddrs *ifa_cur;
-    int result, addr_len;
+    int result;
     void *src;
 
 
@@ -152,6 +150,12 @@ int get_addr_of_if(const char *if_name, int af, void *addr)
         return -1;
     }
 
+    // check the sizeof addr so we won't mess up the stack at memcpy calls
+    if( addr_len != sizeof(struct sockaddr_in6) && addr_len != sizeof(struct sockaddr_in) )
+    {
+        errno = EINVAL;
+        return -1;
+    }
 
     if( getifaddrs(&ifa_head) != 0 )
       return -1;
@@ -179,15 +183,9 @@ int get_addr_of_if(const char *if_name, int af, void *addr)
 
 
         if( af == AF_INET6)
-        {
-            addr_len = sizeof(struct sockaddr_in6);
-            src      = &(((struct sockaddr_in6 *)ifa_cur->ifa_addr)->sin6_addr);
-        }
+            src = &(((struct sockaddr_in6 *)ifa_cur->ifa_addr)->sin6_addr);
         else
-        {
-            addr_len = sizeof(struct sockaddr_in);
-            src      = &(((struct sockaddr_in *)ifa_cur->ifa_addr)->sin_addr);
-        }
+            src = &(((struct sockaddr_in *)ifa_cur->ifa_addr)->sin_addr);
 
 
         memcpy(addr, src, addr_len);

--- a/src/wsdd.c
+++ b/src/wsdd.c
@@ -334,10 +334,13 @@ void init_gsoap()
     // datagrams are to be received.
     struct ip_mreqn mcast;
     mcast.imr_multiaddr.s_addr = inet_addr(WSDD_MULTICAST_IP);
-    if( get_addr_of_if(wsdd_param.if_name, AF_INET, &mcast.imr_address) != 0 )
+
+    struct sockaddr_in addr;
+    if( get_addr_of_if(wsdd_param.if_name, AF_INET, &addr) != 0 )
     {
         daemon_error_exit("Cant get addr for interface error: %m\n");
     }
+    mcast.imr_address = addr.sin_addr;
 
     setsockopt(soap_srv->master, IPPROTO_IP, IP_MULTICAST_IF, &mcast.imr_address.s_addr, sizeof(struct in_addr));
 


### PR DESCRIPTION
At

https://github.com/KoynovStas/wsdd/blob/46ba07be8510bdef6e9213badafb8d71e4f7e60d/src/wsdd.c#L337

We pass the memory address of struct `imr_address` to function `get_addr_of_if`, then `get_addr_of_if` will copy `sizeof(struct sockaddr_in)` amount memory to this address.

https://github.com/KoynovStas/wsdd/blob/46ba07be8510bdef6e9213badafb8d71e4f7e60d/src/net_utils.c#L181-L193

However, `sizeof(struct sockaddr_in)` is larger then `sizeof(struct imr_address)` , so this could cause a potential stack overflow if the compiler doesn't preserve enough memory for stack, or could just mess up with the stack. (For example on a arm machine)